### PR TITLE
correction création de table en SQL

### DIFF
--- a/src/main/resources/db/migration/V1_0_0__init.sql
+++ b/src/main/resources/db/migration/V1_0_0__init.sql
@@ -1,10 +1,10 @@
-create table roles (
+create table if not exists roles (
     id_user bigint not null,
     role varchar(255) not null
-) engine=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-create table users (
-    id_user bigint not null,
+create table if not exists users (
+    id_user bigint not null AUTO_INCREMENT,
     account_non_expired bit,
     account_non_locked bit,
     credentials_non_expired bit,
@@ -14,7 +14,7 @@ create table users (
     password varchar(255) not null,
     username varchar(255) not null,
     primary key (id_user)
-) engine=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 create index INDEX_USER_ROLE on roles (id_user);
 

--- a/src/main/resources/db/migration/V1_1_0__formation_init.sql
+++ b/src/main/resources/db/migration/V1_1_0__formation_init.sql
@@ -3,4 +3,4 @@ CREATE TABLE IF NOT EXISTS `formations` (
     `titre` varchar(250) NOT NULL,
     `num_eleve` int(20) NOT NULL,
     PRIMARY KEY (`formation_id`)
-    ) ENGINE=InnoDB;
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Ok pour toutes les tables sauf la flyway. J'ai essayé plusieurs méthodes, mais pas moyen de créer la table flyway en utf-8 ou de créer la db en utf 8 par défaut via le spring.datasource.url , le seul moyen serait de faire un ALTER TABLE dessus, mais il est fortement déconseillé de toucher manuellement à cette table selon la commu. L'autre moyen serait de manuellement créer la db via phpmyadmin en changeant ses paramètres par défaut(il faudrait alors le rajouter dans le readme de lancement du projet.).  N'oubliez pas de drop votre db avant de faire tourner cette nouvelle version sinon ça va planter.